### PR TITLE
utilize x/text for TitleCase

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module go/swiss
 
 go 1.22.2
+
+require golang.org/x/text v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/text v0.15.0 h1:h1V/4gjBv8v9cjcR6+AR5+/cIYK5N/WAgiv4xlsEtAk=
+golang.org/x/text v0.15.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=

--- a/strings.go
+++ b/strings.go
@@ -2,7 +2,12 @@ package swiss
 
 import (
 	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
+
+var Language = language.English
 
 // IsUpper checks if a string is all uppercase.
 func IsUpper(s string) bool {
@@ -101,19 +106,7 @@ func SnakeCase(s string) string {
 
 // TitleCase converts a string to title case.
 func TitleCase(s string) string {
-	if len(s) < 1 {
-		return s
-	}
-	ss := strings.Split(s, "")
-	ss[0] = strings.ToUpper(ss[0])
-	for i := 1; i < len(ss); i++ {
-		if ss[i-1] == " " {
-			ss[i] = strings.ToUpper(ss[i])
-		} else {
-			ss[i] = strings.ToLower(ss[i])
-		}
-	}
-	return strings.Join(ss, "")
+	return cases.Title(Language).String(s)
 }
 
 // CamelCase converts a string to camel case.


### PR DESCRIPTION
This simplifies a bit.  Notice that our lib doesn't have good language support while looking at the [x/text package](https://cs.opensource.google/go/x/text).  Will choose to be ignorant of that fact for now.  This just simplifies our code a bit and we can look into transformers/casers and language support at a later date.