### PR TITLE
Change a human readable string into a usable time

### DIFF
--- a/time.go
+++ b/time.go
@@ -1,0 +1,116 @@
+package swiss
+
+import (
+	"errors"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var ErrTimeFormat = errors.New("unrecognized time format")
+
+var (
+	datePatterns = map[string]string{
+		"yesterday":    `yesterday`,
+		"today":        `today`,
+		"tomorrow":     `tomorrow`,
+		"minutes_ago":  `(\d+)\s*min(?:ute)?s?\s*ago`,
+		"minutes_from": `in\s*(\d+)\s*min(?:ute)?s?`,
+		"hours_ago":    `(\d+)\s*hour(?:s)?\s*ago`,
+		"hours_from":   `in\s*(\d+)\s*hour(?:s)?`,
+		"days_ago":     `(\d+)\s*day(?:s)?\s*ago`,
+		"days_from":    `in\s*(\d+)\s*day(?:s)?`,
+		"weeks_ago":    `(\d+)\s*week(?:s)?\s*ago`,
+		"weeks_from":   `in\s*(\d+)\s*week(?:s)?`,
+		"months_ago":   `(\d+)\s*month(?:s)?\s*ago`,
+		"months_from":  `in\s*(\d+)\s*month(?:s)?`,
+		"years_ago":    `(\d+)\s*year(?:s)?\s*ago`,
+		"years_from":   `in\s*(\d+)\s*year(?:s)?`,
+	}
+	timeReg = regexp.MustCompile(`at\s*(\d{1,2})(:(\d{2}))?\s*(am|pm)?`)
+)
+
+// TimeFromHumanReadable will take in a string and try to parse out a time.
+func TimeFromHumanReadable(s string) (time.Time, error) {
+	s = strings.ToLower(s) // to lower so we don't need complicated regex
+	now := time.Now().UTC()
+	builtTime := time.Time{}
+
+	for unit, pattern := range datePatterns {
+		re := regexp.MustCompile(pattern)
+		matches := re.FindStringSubmatch(s)
+
+		if len(matches) > 0 {
+			switch unit {
+			case "yesterday":
+				builtTime = now.AddDate(0, 0, -1)
+			case "tomorrow":
+				builtTime = now.AddDate(0, 0, 1)
+			default:
+				amount, err := strconv.Atoi(matches[1])
+				if err != nil {
+					return time.Time{}, err
+				}
+
+				switch unit {
+				case "minutes_ago":
+					builtTime = now.Add(time.Duration(-amount) * time.Minute)
+				case "minutes_from":
+					builtTime = now.Add(time.Duration(amount) * time.Minute)
+				case "hours_ago":
+					builtTime = now.Add(time.Duration(-amount) * time.Hour)
+				case "hours_from":
+					builtTime = now.Add(time.Duration(amount) * time.Hour)
+				case "days_ago":
+					builtTime = now.AddDate(0, 0, -amount)
+				case "days_from":
+					builtTime = now.AddDate(0, 0, amount)
+				case "weeks_ago":
+					builtTime = now.AddDate(0, 0, -amount*7)
+				case "weeks_from":
+					builtTime = now.AddDate(0, 0, amount*7)
+				case "months_ago":
+					builtTime = now.AddDate(0, -amount, 0)
+				case "months_from":
+					builtTime = now.AddDate(0, amount, 0)
+				case "years_ago":
+					builtTime = now.AddDate(-amount, 0, 0)
+				case "years_from":
+					builtTime = now.AddDate(amount, 0, 0)
+				}
+			}
+		}
+	}
+
+	if matches := timeReg.FindStringSubmatch(s); len(matches) > 0 {
+		hour, err := strconv.Atoi(matches[1])
+		if err != nil {
+			return time.Time{}, err
+		}
+
+		minute := 0
+		if matches[3] != "" {
+			minute, err = strconv.Atoi(matches[3])
+			if err != nil {
+				return time.Time{}, err
+			}
+		}
+
+		meridian := matches[4]
+		if meridian == "pm" && hour != 12 {
+			hour += 12
+		}
+		if meridian == "am" && hour == 12 {
+			hour = 0
+		}
+
+		builtTime = time.Date(builtTime.Year(), builtTime.Month(), builtTime.Day(), hour, minute, 0, 0, builtTime.Location())
+	}
+
+	if builtTime.IsZero() {
+		return time.Time{}, ErrTimeFormat
+	}
+
+	return builtTime, nil
+}

--- a/time_test.go
+++ b/time_test.go
@@ -1,0 +1,53 @@
+package swiss
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTimeFromHumanReadable(t *testing.T) {
+	now := time.Now().UTC()
+	tests := []struct {
+		input string
+		want  time.Time
+	}{
+		{"yesterday", now.AddDate(0, 0, -1)},
+		{"5 mins ago", now.Add(-5 * time.Minute)},
+		{"5 minutes ago", now.Add(-5 * time.Minute)},
+		{"1 week ago", now.AddDate(0, 0, -7)},
+		{"tomorrow", now.AddDate(0, 0, 1)},
+		{"in 5 minutes", now.Add(5 * time.Minute)},
+		{"in 3 weeks", now.AddDate(0, 0, 21)},
+		{"tomorrow at 4:00 AM", time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0, 0, now.Location()).AddDate(0, 0, 1)},
+		{"in 1 year", now.AddDate(1, 0, 0)},
+		{"in 12 months", now.AddDate(1, 0, 0)},
+		{"6 months ago", now.AddDate(0, -6, 0)},
+		{"yesterday at 4AM", time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0, 0, now.Location()).AddDate(0, 0, -1)},
+	}
+	for _, test := range tests {
+		got, err := TimeFromHumanReadable(test.input)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		if got.IsZero() {
+			t.Errorf("TimeFromHumanReadable(%v) returned zero time", test.input)
+			continue
+		}
+
+		if !withinDurationJitter(got, test.want, time.Second) {
+			t.Errorf("TimeFromHumanReadable(%v) = %v; want %v", test.input, got, test.want)
+		}
+	}
+}
+
+// withinDurationJitter checks if two times are withing a given duration of
+// eachother, so the nanoseconds don't cause flaky tests.
+func withinDurationJitter(t1, t2 time.Time, d time.Duration) bool {
+	diff := t1.Sub(t2)
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff <= d
+}

--- a/time_test.go
+++ b/time_test.go
@@ -1,6 +1,7 @@
 package swiss
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -36,10 +37,18 @@ func TestTimeFromHumanReadable(t *testing.T) {
 			continue
 		}
 
+		fmt.Println(got)
 		if !withinDurationJitter(got, test.want, time.Second) {
 			t.Errorf("TimeFromHumanReadable(%v) = %v; want %v", test.input, got, test.want)
 		}
 	}
+}
+
+func ExampleTimeFromHumanReadable() {
+	fmt.Println(TimeFromHumanReadable("yesterday at 4AM"))
+
+	// Output:
+	// 2024-06-07 04:00:00 +0000 UTC
 }
 
 // withinDurationJitter checks if two times are withing a given duration of


### PR DESCRIPTION
This is currently using regex patterns to determine the typing. I have tested a handful of readable times but we can always expand this further.

I was thinking of possibly making `currentTime()` to override in tests so we could have constant time in the test that runs but seemed a bit over kill just to handle tests, but changed my mind to check on Jitter being within a short time.

Curious on thoughts for the test.

## Example

```go
// time.go
// line #30
var currentTime = time.Now

func TimeFromHumanReadable(s string) (time.Time, error) {
	s = strings.ToLower(s) // to lower so we don't need complicated regex
	now := currentTime()
}
```

```go
func TestTimeFromHumanReadable(t *testing.T) {
	fixedTime := time.Date(2024, 6, 7, 15, 0, 0, 0, time.UTC)
	currentTime = func() time.Time {
		return fixedTime
	}

        // use fixedTime for the tests rather than now
}
```
